### PR TITLE
Use window.location.hash instead of parsing the href

### DIFF
--- a/avs.js
+++ b/avs.js
@@ -258,15 +258,9 @@
 
     getTokenFromUrl() {
       return new Promise((resolve, reject) => {
-        let queryString = window.location.href.split('?#');
+        let hash = window.location.hash.replace('#', '');
 
-        if (queryString.length === 2) {
-          queryString = queryString[1];
-        } else {
-          queryString = window.location.search.substr(1);
-        }
-
-        const query = qs.parse(queryString);
+        const query = qs.parse(hash);
         const token = query.access_token;
         const refreshToken = query.refresh_token;
         const tokenType = query.token_type;


### PR DESCRIPTION
I know this library is still in alpha but…figured I'd give it a shot anyway :)

In my alexa setup, I get directed to http://mywebsite.com/redirect-path#access_token Note that my url does not have the "?" that you include in getTokenFromUrl. I assume the "?" is something custom you setup in the Alexa Voice Services admin.

Thankfully, we can easily access the hash by just using `window.location.hash` and it will work in both cases.

In your URL "http://mywebsite.com/redirect-path?#access_token":

window.location.href === "redirect-path?#access_token"
window.location.search === ""
window.location.hash === "#access_token"
